### PR TITLE
Build system integration improvement

### DIFF
--- a/config/openiotsdk/CMakeLists.txt
+++ b/config/openiotsdk/CMakeLists.txt
@@ -89,7 +89,6 @@ endmacro()
 # ==============================================================================
 # Prepare CHIP configuration based on the project configuration
 # ==============================================================================
-
 # Set paths
 if (NOT CHIP_ROOT)
     get_filename_component(CHIP_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../.. REALPATH)

--- a/config/openiotsdk/CMakeLists.txt
+++ b/config/openiotsdk/CMakeLists.txt
@@ -97,61 +97,24 @@ endif()
 set(GN_ROOT_TARGET ${CHIP_ROOT}/config/openiotsdk/chip-gn)
 
 # Prepare compiler flags
+# All Open IoT SDK targets
+list(APPEND ALL_SDK_TARGETS)
 
-if (TARGET mdh-reference-platforms-for-arm)
-    get_target_common_compile_flags(CHIP_MDH_ARM_CFLAGS mdh-reference-platforms-for-arm)
-    list(APPEND CHIP_CFLAGS ${CHIP_MDH_ARM_CFLAGS})
-    get_target_common_compile_flags(CHIP_MCU_DRIVER_HAL_CFLAGS mcu-driver-hal)
-    list(APPEND CHIP_CFLAGS ${CHIP_MCU_DRIVER_HAL_CFLAGS}) 
-endif()
+foreach(source_dir ${SDK_SOURCES_BINARY_DIRS})
+    get_all_cmake_targets(SDK_TARGETS ${source_dir})
+    list(APPEND ALL_SDK_TARGETS ${SDK_TARGETS})
+endforeach()
 
-if (TARGET cmsis-rtos-api)
-    get_target_common_compile_flags(CHIP_CMSIS_RTOS_API_CFLAGS cmsis-rtos-api)
-    list(APPEND CHIP_CFLAGS ${CHIP_CMSIS_RTOS_API_CFLAGS})    
-    get_target_common_compile_flags(CHIP_CMSIS_RTOS_CORE_CFLAGS cmsis-core)
-    list(APPEND CHIP_CFLAGS ${CHIP_CMSIS_RTOS_CORE_CFLAGS})
-endif()
+# Exclude unnecessary targets
+list(FILTER ALL_SDK_TARGETS EXCLUDE REGEX "^.*linker.*|.*example.*|.*apps.*|.*doc.*|dist|lib$")
 
-if (TARGET freertos-cmsis-rtos)
-    get_target_common_compile_flags(CHIP_FREERTOS_CMSIS_RTOS_CFLAGS freertos-cmsis-rtos)
-    list(APPEND CHIP_CFLAGS ${CHIP_FREERTOS_CMSIS_RTOS_CFLAGS})
-    get_target_common_compile_flags(CHIP_FREERTOS_KERNEL_CFLAGS freertos-kernel)
-    list(APPEND CHIP_CFLAGS ${CHIP_FREERTOS_KERNEL_CFLAGS})
-endif()
+foreach(target ${ALL_SDK_TARGETS})
+    get_target_common_compile_flags(SDK_TARGET_CFLAGS ${target})
+    list(APPEND CHIP_CFLAGS ${SDK_TARGET_CFLAGS})
+endforeach()
 
-if (TARGET mbedtls)
-    get_target_common_compile_flags(CHIP_MBEDTLS_CFLAGS mbedtls)
-    list(APPEND CHIP_CFLAGS ${CHIP_MBEDTLS_CFLAGS})
-endif()
-
-if (TARGET iotsdk-ip-network-api)
-    get_target_common_compile_flags(CHIP_IP_NETOWORK_CFLAGS iotsdk-ip-network-api)
-    list(APPEND CHIP_CFLAGS ${CHIP_IP_NETOWORK_CFLAGS})
-endif()
-
-if (TARGET lwipcore)
-    get_target_common_compile_flags(CHIP_LWIP_CFLAGS lwipcore)
-    list(APPEND CHIP_CFLAGS ${CHIP_LWIP_CFLAGS})
-endif()
-
-if (TARGET lwip-cmsis-port)
-    get_target_common_compile_flags(CHIP_LWIP_CMSIS_PORT_CFLAGS lwip-cmsis-port)
-    list(APPEND CHIP_CFLAGS ${CHIP_LWIP_CMSIS_PORT_CFLAGS})
-    get_target_common_compile_flags(CHIP_LWIP_OPTS_CFLAGS lwipopts)
-    list(APPEND CHIP_CFLAGS ${CHIP_LWIP_OPTS_CFLAGS})
-    get_target_common_compile_flags(CHIP_LWIP_CMSIS_SYS_CFLAGS lwip-cmsis-sys)
-    list(APPEND CHIP_CFLAGS ${CHIP_LWIP_CMSIS_SYS_CFLAGS})
-endif()
-
-if (TARGET iotsdk-blockdevice)
-    get_target_common_compile_flags(CHIP_STORAGE_BLOCK_DEVICE_CFLAGS iotsdk-blockdevice)
-    list(APPEND CHIP_CFLAGS ${CHIP_STORAGE_BLOCK_DEVICE_CFLAGS})
-endif()
-
-if (TARGET iotsdk-tdbstore)
-    get_target_common_compile_flags(CHIP_STORAGE_KV_STORE_CFLAGS iotsdk-tdbstore)
-    list(APPEND CHIP_CFLAGS ${CHIP_STORAGE_KV_STORE_CFLAGS})
-endif()
+# Remove duplicated flags
+list(REMOVE_DUPLICATES CHIP_CFLAGS)
 
 get_gnu_cpp_standard(CHIP_CFLAGS_CC)
 

--- a/config/openiotsdk/CMakeLists.txt
+++ b/config/openiotsdk/CMakeLists.txt
@@ -227,11 +227,12 @@ ExternalProject_Add(
 )
 
 # ==============================================================================
-# Define 'chip' target that exposes CHIP headers & libraries to the application
+# Define 'openiotsdk-chip' target that exposes CHIP and Open IoT SDK 
+# headers & libraries to the application
 # ==============================================================================
-add_library(chip INTERFACE)
-target_compile_definitions(chip INTERFACE CHIP_HAVE_CONFIG_H)
-target_include_directories(chip INTERFACE
+add_library(openiotsdk-chip INTERFACE)
+target_compile_definitions(openiotsdk-chip INTERFACE CHIP_HAVE_CONFIG_H)
+target_include_directories(openiotsdk-chip INTERFACE
     ${CHIP_ROOT}/src
     ${CHIP_ROOT}/src/include
     ${CHIP_ROOT}/src/lib
@@ -240,9 +241,18 @@ target_include_directories(chip INTERFACE
     ${CHIP_ROOT}/zzz_generated/app-common
     ${CMAKE_CURRENT_BINARY_DIR}/gen/include
 )
-target_link_directories(chip INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/lib)
-target_link_libraries(chip INTERFACE -Wl,--start-group ${CHIP_LIBRARIES} -Wl,--end-group)
-add_dependencies(chip chip-gn)
+target_link_directories(openiotsdk-chip INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/lib)
+target_link_libraries(openiotsdk-chip INTERFACE -Wl,--start-group ${CHIP_LIBRARIES} -Wl,--end-group)
+target_link_libraries(openiotsdk-chip INTERFACE
+    $<$<TARGET_EXISTS:mcu-driver-hal>:mcu-driver-hal>
+    $<$<TARGET_EXISTS:mcu-driver-bootstrap>:mcu-driver-bootstrap>
+    $<$<TARGET_EXISTS:mdh-reference-platforms-for-arm>:mdh-reference-platforms-for-arm>
+    $<$<TARGET_EXISTS:mbedtls>:mbedtls>
+    $<$<TARGET_EXISTS:lwipcore>:lwipcore>
+    $<$<TARGET_EXISTS:iotsdk-ip-network-api>:iotsdk-ip-network-api>
+    $<$<TARGET_EXISTS:iotsdk-serial-retarget>:$<TARGET_OBJECTS:iotsdk-serial-retarget>>
+)
+add_dependencies(openiotsdk-chip chip-gn)
 
 # ==============================================================================
 # Parent target configuration according to CHIP component usage

--- a/config/openiotsdk/chip-gn/mbedtls/BUILD.gn
+++ b/config/openiotsdk/chip-gn/mbedtls/BUILD.gn
@@ -12,16 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import("//build_overrides/chip.gni")
-
-config("mbedtls_config") {
-  include_dirs = [ "${chip_root}/config/openiotsdk/mbedtls" ]
-  defines = [
-      "MBEDTLS_CONFIG_FILE=<mbedtls_config.h>"
-  ]
-}
-
-# Open IoT SDK has its own mbedtls library, just provide a target and configuraiton
+# Open IoT SDK has its own mbedtls library, just provide empty target
 group("mbedtls") {
-    public_configs = [ ":mbedtls_config" ]
 }

--- a/config/openiotsdk/util.cmake
+++ b/config/openiotsdk/util.cmake
@@ -1,5 +1,5 @@
 #
-#   Copyright (c) 2020 Project CHIP Authors
+#   Copyright (c) 2022 Project CHIP Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -136,4 +136,17 @@ function(convert_list_of_flags_to_string_of_flags ptr_list_of_flags string_of_fl
 
   # Set the output variable in the parent scope
   set(${string_of_flags} ${locally_scoped_string_of_flags} PARENT_SCOPE)
+endfunction()
+
+
+function (get_all_cmake_targets out_var current_dir)
+    get_property(targets DIRECTORY ${current_dir} PROPERTY BUILDSYSTEM_TARGETS)
+    get_property(subdirs DIRECTORY ${current_dir} PROPERTY SUBDIRECTORIES)
+
+    foreach(subdir ${subdirs})
+        get_all_cmake_targets(subdir_targets ${subdir})
+        list(APPEND targets ${subdir_targets})
+    endforeach()
+
+    set(${out_var} ${targets} PARENT_SCOPE)
 endfunction()

--- a/examples/platform/openiotsdk/cmake/chip.cmake
+++ b/examples/platform/openiotsdk/cmake/chip.cmake
@@ -1,0 +1,28 @@
+#
+#   Copyright (c) 2022 Project CHIP Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+#
+#   @file
+#     CMake for CHIP library configuration
+#
+
+# Default CHIP build configuration 
+set(CONFIG_CHIP_PROJECT_CONFIG "main/include/CHIPProjectConfig.h" CACHE STRING "")
+set(CONFIG_CHIP_LIB_TESTS NO CACHE BOOL "")
+set(CONFIG_CHIP_LIB_SHELL NO CACHE BOOL "")
+
+# Add CHIP sources
+add_subdirectory(${OPEN_IOT_SDK_CONFIG} ./chip_build)

--- a/examples/platform/openiotsdk/cmake/linker.cmake
+++ b/examples/platform/openiotsdk/cmake/linker.cmake
@@ -1,0 +1,33 @@
+#
+#   Copyright (c) 2022 Project CHIP Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+#
+#   @file
+#     CMake linker configuration for target
+#
+
+function(set_target_link target)
+    target_link_libraries(${target}
+        mdh-platform-startup-linker
+    )
+
+    target_link_options(${target}
+        PRIVATE
+            "-Wl,-Map=${APP_TARGET}.map"
+    )
+endfunction()
+
+set(CMAKE_EXECUTABLE_SUFFIX_CXX .elf)

--- a/examples/platform/openiotsdk/cmake/sdk.cmake
+++ b/examples/platform/openiotsdk/cmake/sdk.cmake
@@ -1,0 +1,115 @@
+#
+#   Copyright (c) 2022 Project CHIP Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+#
+#   @file
+#     CMake for Open IoT SDK configuration
+#
+
+get_filename_component(OPEN_IOT_SDK_SOURCE ${CHIP_ROOT}/third_party/open-iot-sdk/sdk REALPATH)
+get_filename_component(OPEN_IOT_SDK_STORAGE_SOURCE ${CHIP_ROOT}/third_party/open-iot-sdk/storage REALPATH)
+get_filename_component(OPEN_IOT_SDK_TOOLCHAIN ${CHIP_ROOT}/third_party/open-iot-sdk/toolchain REALPATH)
+get_filename_component(OPEN_IOT_SDK_CONFIG ${CHIP_ROOT}/config/openiotsdk REALPATH)
+
+# List of binary directories to Open IoT SDK sources
+list(APPEND SDK_SOURCES_BINARY_DIRS)
+
+# Open IoT SDK configuration
+set(IOTSDK_MDH_ARM ON)
+set(MDH_PLATFORM "ARM_AN552_MPS3")
+set(MDH_ARM_BUILD_EXAMPLES OFF)
+set(IOTSDK_CMSIS_RTOS_API ON)
+set(IOTSDK_FREERTOS ON)
+set(IOTSDK_MBEDTLS ON)
+set(IOTSDK_LWIP ON)
+set(FETCHCONTENT_QUIET OFF)
+set(IOTSDK_EXAMPLES OFF)
+set(VARIANT "FVP")
+
+# Add Open IoT SDK source
+add_subdirectory(${OPEN_IOT_SDK_SOURCE} ./sdk_build)
+list(APPEND SDK_SOURCES_BINARY_DIRS ${CMAKE_CURRENT_BINARY_DIR}/sdk_build)
+
+# CMSIS-RTOS configuration
+# CMSIS 5 require projects to provide configuration macros via RTE_Components.h
+# and CMSIS_device_header. The macro CMSIS_device_header is not automatically set
+# based on CMAKE_SYSTEM_PROCESSOR in the place where cmsis-core is first defined,
+# because a project may want to provide its own device header.
+if(TARGET cmsis-rtos-api)
+    target_include_directories(cmsis-rtos-api
+            PUBLIC
+                cmsis-config
+    )
+endif()
+
+if(TARGET cmsis-core)
+    target_compile_definitions(cmsis-core
+        INTERFACE
+            $<$<STREQUAL:${CMAKE_SYSTEM_PROCESSOR},cortex-m55>:CMSIS_device_header="ARMCM55.h">
+    )
+endif()
+
+# LwIP configuration
+if(TARGET lwip-cmsis-port)
+    # lwipcore requires the config defined by lwip-cmsis-port
+    target_link_libraries(lwipcore
+        PUBLIC
+            lwip-cmsis-port
+    )
+
+    # lwip requires user_lwipopts.h, we use the template provided by the lwip-cmsis-port
+    get_target_property(lwip-cmsis-port_SOURCE_DIR lwip-cmsis-port SOURCE_DIR)
+    target_include_directories(lwipopts
+        INTERFACE
+            ${OPEN_IOT_SDK_CONFIG}/lwip
+    )
+
+    # provide method to use for tracing by the lwip port (optional)
+    target_compile_definitions(lwipopts
+        INTERFACE
+            DEBUG_PRINT=printf
+    )
+
+    if(TARGET lwip-cmsis-port)
+        # Link the emac factory to LwIP port
+        target_link_libraries(lwip-cmsis-port PUBLIC iotsdk-emac-factory)
+    endif()
+endif()
+
+# MDH configuration
+if(TARGET ethernet-lan91c111)
+    target_compile_definitions(ethernet-lan91c111
+        INTERFACE
+            LAN91C111_RFS_MULTICAST_SUPPORT
+    )
+endif()
+
+# Mbedtls config
+if(TARGET mbedtls-config)
+    target_include_directories(mbedtls-config
+        INTERFACE
+            ${OPEN_IOT_SDK_CONFIG}/mbedtls
+    )
+
+    target_compile_definitions(mbedtls-config
+        INTERFACE
+            MBEDTLS_CONFIG_FILE="mbedtls_config.h"
+    )
+endif()
+
+# Add Open IoT SDK storage source
+add_subdirectory(${OPEN_IOT_SDK_STORAGE_SOURCE} ./sdk_storage_build)
+list(APPEND SDK_SOURCES_BINARY_DIRS ${CMAKE_CURRENT_BINARY_DIR}/sdk_storage_build)

--- a/examples/platform/openiotsdk/cmake/sdk.cmake
+++ b/examples/platform/openiotsdk/cmake/sdk.cmake
@@ -110,6 +110,28 @@ if(TARGET mbedtls-config)
     )
 endif()
 
+# Declare RTOS interface target
+add_library(cmsis-rtos-implementation INTERFACE)
+
+if(TARGET freertos-kernel)
+    target_link_libraries(cmsis-rtos-implementation
+        INTERFACE
+            freertos-cmsis-rtos
+            freertos-kernel-heap-3
+    )
+    target_include_directories(cmsis-rtos-implementation 
+        INTERFACE
+            ${CMAKE_CURRENT_SOURCE_DIR}/freertos-config
+    )
+elseif(TARGET cmsis-rtx)
+    target_link_libraries(cmsis-rtos-implementation
+        INTERFACE
+            cmsis-rtx
+            cmsis-rtos-api
+            cmsis-rtx-freertos-alloc-wrapper
+    )
+endif()
+
 # Add Open IoT SDK storage source
 add_subdirectory(${OPEN_IOT_SDK_STORAGE_SOURCE} ./sdk_storage_build)
 list(APPEND SDK_SOURCES_BINARY_DIRS ${CMAKE_CURRENT_BINARY_DIR}/sdk_storage_build)

--- a/examples/shell/openiotsdk/CMakeLists.txt
+++ b/examples/shell/openiotsdk/CMakeLists.txt
@@ -34,27 +34,15 @@ include(${OPENIOTSDK_COMMON}/cmake/chip.cmake)
 target_include_directories(${APP_TARGET} PRIVATE
                            main/include
                            ${SHELL_COMMON}/include
-                           freertos-config
 )
 
 target_sources(${APP_TARGET} PRIVATE
                 main/main.cpp
 )
 
-target_link_libraries(${APP_TARGET}
-    mcu-driver-hal
-    mcu-driver-bootstrap
-    mdh-reference-platforms-for-arm
-
-    iotsdk-serial-retarget
-    freertos-cmsis-rtos
-    freertos-kernel-heap-3
-
-    iotsdk-ip-network-api
-    lwipcore
-    mbedtls
-    
-    chip
+target_link_libraries(${APP_TARGET} 
+    cmsis-rtos-implementation
+    openiotsdk-chip
 )
 
 include(${OPENIOTSDK_COMMON}/cmake/linker.cmake)

--- a/examples/shell/openiotsdk/CMakeLists.txt
+++ b/examples/shell/openiotsdk/CMakeLists.txt
@@ -16,112 +16,23 @@
 
 cmake_minimum_required(VERSION 3.21)
 
-# # Fetch toolchain files before the first call to project
-include(FetchContent)
-FetchContent_Declare(iotsdk-toolchains
-    GIT_REPOSITORY  https://git.gitlab.arm.com/iot/open-iot-sdk/toolchain.git
-    GIT_TAG         v2022.05
-    SOURCE_DIR      ${CMAKE_BINARY_DIR}/toolchains
-)
-FetchContent_MakeAvailable(iotsdk-toolchains)
-
 get_filename_component(CHIP_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../.. REALPATH)
+get_filename_component(OPENIOTSDK_COMMON ${CHIP_ROOT}/examples/platform/openiotsdk REALPATH)
 get_filename_component(SHELL_COMMON ${CHIP_ROOT}/examples/shell/shell_common REALPATH)
-get_filename_component(OPEN_IOT_SDK_SOURCE ${CHIP_ROOT}/third_party/open-iot-sdk/sdk REALPATH)
-get_filename_component(OPEN_IOT_SDK_STORAGE_SOURCE ${CHIP_ROOT}/third_party/open-iot-sdk/storage REALPATH)
-get_filename_component(OPEN_IOT_SDK_TOOLCHAIN ${CHIP_ROOT}/third_party/open-iot-sdk/toolchain REALPATH)
-get_filename_component(OPEN_IOT_SDK_CONFIG ${CHIP_ROOT}/config/openiotsdk REALPATH)
 
 set(APP_TARGET chip-openiotsdk-shell-example)
-set(CMAKE_EXECUTABLE_SUFFIX_CXX .elf)
+
+include(${OPENIOTSDK_COMMON}/cmake/sdk.cmake)
 
 project(${APP_TARGET} LANGUAGES C CXX ASM)
 add_executable(${APP_TARGET})
 
-# Open IoT SDK configuration
-set(IOTSDK_MDH_ARM ON)
-set(MDH_PLATFORM "ARM_AN552_MPS3")
-set(IOTSDK_CMSIS_RTOS_API ON)
-set(IOTSDK_FREERTOS ON)
-set(IOTSDK_MBEDTLS ON)
-set(IOTSDK_LWIP ON)
-set(FETCHCONTENT_QUIET OFF)
-set(IOTSDK_EXAMPLES OFF)
-set(VARIANT "FVP")
-
-# Add Open IoT SDK source
-add_subdirectory(${OPEN_IOT_SDK_SOURCE} ./sdk_build)
-add_subdirectory(${OPEN_IOT_SDK_SOURCE}/utils ./sdk_utils_build)
-
-# CMSIS-RTOS configuration
-
-# CMSIS 5 require projects to provide configuration macros via RTE_Components.h
-# and CMSIS_device_header. The macro CMSIS_device_header is not automatically set
-# based on CMAKE_SYSTEM_PROCESSOR in the place where cmsis-core is first defined,
-# because a project may want to provide its own device header.
-target_include_directories(cmsis-rtos-api
-        PUBLIC
-            cmsis-config
-)
-target_compile_definitions(cmsis-core
-    INTERFACE
-        $<$<STREQUAL:${CMAKE_SYSTEM_PROCESSOR},cortex-m55>:CMSIS_device_header="ARMCM55.h">
-)
-
-# LwIP configuration
-
-# lwipcore requires the config defined by lwip-cmsis-port
-target_link_libraries(lwipcore
-    PUBLIC
-        lwip-cmsis-port
-)
-
-# lwip requires user_lwipopts.h, we use the template provided by the lwip-cmsis-port
-get_target_property(lwip-cmsis-port_SOURCE_DIR lwip-cmsis-port SOURCE_DIR)
-target_include_directories(lwipopts
-    INTERFACE
-        ${OPEN_IOT_SDK_CONFIG}/lwip
-)
-
-# provide method to use for tracing by the lwip port (optional)
-target_compile_definitions(lwipopts
-    INTERFACE
-        DEBUG_PRINT=printf
-)
-
-target_compile_definitions(mdh-arm-an552-mps3
-    INTERFACE
-        LAN91C111_RFS_MULTICAST_SUPPORT
-)
-
-# Link the emac factory to LwIP port
-target_link_libraries(lwip-cmsis-port PUBLIC iotsdk-emac-factory)
-
-# Mbedtls config
-
-target_include_directories(mbedtls-config
-    INTERFACE
-        ${OPEN_IOT_SDK_CONFIG}/mbedtls
-)
-
-target_compile_definitions(mbedtls-config
-    INTERFACE
-        MBEDTLS_CONFIG_FILE="mbedtls_config.h"
-)
-
-# Add Open IoT SDK storage source
-add_subdirectory(${OPEN_IOT_SDK_STORAGE_SOURCE} ./sdk_storage_build)
-
-# CHIP configuration
-set(CONFIG_CHIP_PROJECT_CONFIG main/include/CHIPProjectConfig.h)
-set(CONFIG_CHIP_BUILD_TESTS NO)
-set(CONFIG_CHIP_LIB_SHELL NO)
-
-add_subdirectory(${OPEN_IOT_SDK_CONFIG} ./chip_build)
+# Application CHIP build configuration 
+set(CONFIG_CHIP_LIB_SHELL YES)
+include(${OPENIOTSDK_COMMON}/cmake/chip.cmake)
 
 target_include_directories(${APP_TARGET} PRIVATE
                            main/include
-                           ${MBED_COMMON}/util/include
                            ${SHELL_COMMON}/include
                            freertos-config
 )
@@ -144,12 +55,7 @@ target_link_libraries(${APP_TARGET}
     mbedtls
     
     chip
-
-    $<$<TARGET_EXISTS:mdh-arm-an552-mps3>:mdh-arm-corstone-300-startup>
-    $<$<TARGET_EXISTS:mdh-arm-an552-mps3>:mdh-arm-an552-mps3-linker>
 )
 
-target_link_options(${APP_TARGET}
-    PRIVATE
-        "-Wl,-Map=${APP_TARGET}.map"
-)
+include(${OPENIOTSDK_COMMON}/cmake/linker.cmake)
+set_target_link(${APP_TARGET})

--- a/src/test_driver/openiotsdk/unit-tests/CMakeLists.txt
+++ b/src/test_driver/openiotsdk/unit-tests/CMakeLists.txt
@@ -16,107 +16,19 @@
 
 cmake_minimum_required(VERSION 3.21)
 
-# # Fetch toolchain files before the first call to project
-include(FetchContent)
-FetchContent_Declare(iotsdk-toolchains
-    GIT_REPOSITORY  https://git.gitlab.arm.com/iot/open-iot-sdk/toolchain.git
-    GIT_TAG         v2022.05
-    SOURCE_DIR      ${CMAKE_BINARY_DIR}/toolchains
-)
-FetchContent_MakeAvailable(iotsdk-toolchains)
-
 get_filename_component(CHIP_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../../.. REALPATH)
-get_filename_component(OPEN_IOT_SDK_SOURCE ${CHIP_ROOT}/third_party/open-iot-sdk/sdk REALPATH)
-get_filename_component(OPEN_IOT_SDK_STORAGE_SOURCE ${CHIP_ROOT}/third_party/open-iot-sdk/storage REALPATH)
-get_filename_component(OPEN_IOT_SDK_TOOLCHAIN ${CHIP_ROOT}/third_party/open-iot-sdk/toolchain REALPATH)
-get_filename_component(OPEN_IOT_SDK_CONFIG ${CHIP_ROOT}/config/openiotsdk REALPATH)
+get_filename_component(OPENIOTSDK_COMMON ${CHIP_ROOT}/examples/platform/openiotsdk REALPATH)
 
 set(APP_TARGET chip-openiotsdk-unit-tests)
-set(CMAKE_EXECUTABLE_SUFFIX_CXX .elf)
+
+include(${OPENIOTSDK_COMMON}/cmake/sdk.cmake)
 
 project(${APP_TARGET} LANGUAGES C CXX ASM)
 add_executable(${APP_TARGET})
 
-# Open IoT SDK configuration
-set(IOTSDK_MDH_ARM ON)
-set(MDH_PLATFORM "ARM_AN552_MPS3")
-set(IOTSDK_CMSIS_RTOS_API ON)
-set(IOTSDK_FREERTOS ON)
-set(IOTSDK_MBEDTLS ON)
-set(IOTSDK_LWIP ON)
-set(FETCHCONTENT_QUIET OFF)
-set(IOTSDK_EXAMPLES OFF)
-set(VARIANT "FVP")
-
-# Add Open IoT SDK source
-add_subdirectory(${OPEN_IOT_SDK_SOURCE} ./sdk_build)
-add_subdirectory(${OPEN_IOT_SDK_SOURCE}/utils ./sdk_utils_build)
-
-# CMSIS-RTOS configuration
-
-# CMSIS 5 require projects to provide configuration macros via RTE_Components.h
-# and CMSIS_device_header. The macro CMSIS_device_header is not automatically set
-# based on CMAKE_SYSTEM_PROCESSOR in the place where cmsis-core is first defined,
-# because a project may want to provide its own device header.
-target_include_directories(cmsis-rtos-api
-        PUBLIC
-            cmsis-config
-)
-target_compile_definitions(cmsis-core
-    INTERFACE
-        $<$<STREQUAL:${CMAKE_SYSTEM_PROCESSOR},cortex-m55>:CMSIS_device_header="ARMCM55.h">
-)
-
-# LwIP configuration
-
-# lwipcore requires the config defined by lwip-cmsis-port
-target_link_libraries(lwipcore
-    PUBLIC
-        lwip-cmsis-port
-)
-
-# lwip requires user_lwipopts.h, we use the template provided by the lwip-cmsis-port
-get_target_property(lwip-cmsis-port_SOURCE_DIR lwip-cmsis-port SOURCE_DIR)
-target_include_directories(lwipopts
-    INTERFACE
-        ${OPEN_IOT_SDK_CONFIG}/lwip
-)
-
-# provide method to use for tracing by the lwip port (optional)
-target_compile_definitions(lwipopts
-    INTERFACE
-        DEBUG_PRINT=printf
-)
-
-target_compile_definitions(mdh-arm-an552-mps3
-    INTERFACE
-        LAN91C111_RFS_MULTICAST_SUPPORT
-)
-
-# Link the emac factory to LwIP port
-target_link_libraries(lwip-cmsis-port PUBLIC iotsdk-emac-factory)
-
-# Mbedtls config
-
-target_include_directories(mbedtls-config
-    INTERFACE
-        ${OPEN_IOT_SDK_CONFIG}/mbedtls
-)
-
-target_compile_definitions(mbedtls-config
-    INTERFACE
-        MBEDTLS_CONFIG_FILE="mbedtls_config.h"
-)
-
-# Add Open IoT SDK storage source
-add_subdirectory(${OPEN_IOT_SDK_STORAGE_SOURCE} ./sdk_storage_build)
-
-# CHIP configuration
-set(CONFIG_CHIP_PROJECT_CONFIG main/include/CHIPProjectConfig.h)
+# Application CHIP build configuration 
 set(CONFIG_CHIP_LIB_TESTS YES)
-set(CONFIG_CHIP_LIB_SHELL NO)
-
-add_subdirectory(${OPEN_IOT_SDK_CONFIG} ./chip_build)
+include(${OPENIOTSDK_COMMON}/cmake/chip.cmake)
 
 target_include_directories(${APP_TARGET} PRIVATE
                            main/include
@@ -141,15 +53,10 @@ target_link_libraries(${APP_TARGET}
     mbedtls
     
     chip
-
-    $<$<TARGET_EXISTS:mdh-arm-an552-mps3>:mdh-arm-corstone-300-startup>
-    $<$<TARGET_EXISTS:mdh-arm-an552-mps3>:mdh-arm-an552-mps3-linker>
 )
 
 # Link the *whole-archives* to keep the static test objects.
 target_link_options(${APP_TARGET} PUBLIC -Wl,--whole-archive "${CMAKE_CURRENT_BINARY_DIR}/chip_build/lib/libCHIP_tests_custom.a" -Wl,--no-whole-archive)
 
-target_link_options(${APP_TARGET}
-    PRIVATE
-        "-Wl,-Map=${APP_TARGET}.map"
-)
+include(${OPENIOTSDK_COMMON}/cmake/linker.cmake)
+set_target_link(${APP_TARGET})

--- a/src/test_driver/openiotsdk/unit-tests/CMakeLists.txt
+++ b/src/test_driver/openiotsdk/unit-tests/CMakeLists.txt
@@ -32,28 +32,13 @@ include(${OPENIOTSDK_COMMON}/cmake/chip.cmake)
 
 target_include_directories(${APP_TARGET} PRIVATE
                            main/include
-                           freertos-config
 )
 
 target_sources(${APP_TARGET} PRIVATE
                 main/main.cpp
 )
 
-target_link_libraries(${APP_TARGET}
-    mcu-driver-hal
-    mcu-driver-bootstrap
-    mdh-reference-platforms-for-arm
-
-    iotsdk-serial-retarget
-    freertos-cmsis-rtos
-    freertos-kernel-heap-3
-
-    iotsdk-ip-network-api
-    lwipcore
-    mbedtls
-    
-    chip
-)
+target_link_libraries(${APP_TARGET} openiotsdk-chip)
 
 # Link the *whole-archives* to keep the static test objects.
 target_link_options(${APP_TARGET} PUBLIC -Wl,--whole-archive "${CMAKE_CURRENT_BINARY_DIR}/chip_build/lib/libCHIP_tests_custom.a" -Wl,--no-whole-archive)


### PR DESCRIPTION
#### Problem
Implement some improvements for Cmake and GN build system integration:

- application Cmake files contain many common lines - nice to have some common settings
- passing Cmake targets properties to GN means a long list of the same definitions - collect all SDK targets to a single variable and use loops for getting properties from them

#### Change overview
- Create common Cmake settings
   - Add toolchain, sdk, chip and linker common cmake files in `examples/platform/openiotsdk/cmake directory`
   - Use common cmake files in shell and unit-test projects
   - Move chip library configuration to a separate config file
   - Read configuration file and parse it content to create cmake variable

- Improve passing targets settings to GN build
   - Add getting all cmake targets from directory function
   - Collect all SDK targets from build directories to get all properties
   - Exclude linker script targets and remove duplicated flags

- Extend chip target with Open IoT SDK dependencies
   - Rename chip target to openiotsdk-chip
   - Include SDK dependencies to openiotsdk-chip target
   - Use openiotsdk-chip target in shell example and unit-tests app

#### Testing
Build and run shell example and unit-tests app
