### PR TITLE
Open IoT SDK example platform target

### DIFF
--- a/config/openiotsdk/CMakeLists.txt
+++ b/config/openiotsdk/CMakeLists.txt
@@ -257,29 +257,12 @@ target_link_libraries(openiotsdk-chip INTERFACE
 )
 add_dependencies(openiotsdk-chip chip-gn)
 
-# ==============================================================================
-# Parent target configuration according to CHIP component usage
-# ==============================================================================
-# CHIP includes path
-list(APPEND CHIP_INCLUDES)
-
-# CHIP defines
-list(APPEND CHIP_DEFINES)
-
-list(APPEND CHIP_INCLUDES
+target_include_directories(openiotsdk-chip INTERFACE
     ${CHIP_ROOT}/config/openiotsdk/mbedtls
 )
 
 if (NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug")
-    list(APPEND CHIP_DEFINES
+    target_compile_definitions(openiotsdk-chip INTERFACE
         NDEBUG
     )
 endif()
-
-target_include_directories(${APP_TARGET} PRIVATE
-                           ${CHIP_INCLUDES}
-)
-
-target_compile_definitions(${APP_TARGET} PRIVATE
-                           ${CHIP_DEFINES}
-)

--- a/examples/platform/openiotsdk/app/CMakeLists.txt
+++ b/examples/platform/openiotsdk/app/CMakeLists.txt
@@ -1,0 +1,33 @@
+#
+#   Copyright (c) 2022 Project CHIP Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+cmake_minimum_required(VERSION 3.21)
+
+# Declare Open IoT SDK app interface target
+add_library(openiotsdk-app
+    openiotsdk_platform.cpp    
+)
+
+target_include_directories(openiotsdk-app 
+    PUBLIC
+        .
+)
+
+target_link_libraries(openiotsdk-app 
+    PUBLIC
+        openiotsdk-chip
+        cmsis-rtos-implementation
+)

--- a/examples/platform/openiotsdk/app/openiotsdk_platform.cpp
+++ b/examples/platform/openiotsdk/app/openiotsdk_platform.cpp
@@ -1,0 +1,189 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file provides the common Open IoT SDK platform functions.
+ *      It can be used in Matter examples implementation.
+ */
+
+#include "openiotsdk_platform.h"
+
+#include "cmsis_os2.h"
+#include "iotsdk/ip_network_api.h"
+#include "mbedtls/platform.h"
+
+#include <lib/core/CHIPConfig.h>
+#include <lib/support/CHIPMem.h>
+#include <lib/support/logging/CHIPLogging.h>
+#include <platform/CHIPDeviceLayer.h>
+
+using namespace ::chip;
+using namespace ::chip::Platform;
+using namespace ::chip::DeviceLayer;
+using namespace ::chip::Logging::Platform;
+
+#define NETWORK_UP_FLAG 0x00000001U
+#define NETWORK_DOWN_FLAG 0x00000002U
+#define ALL_EVENTS_FLAGS (NETWORK_UP_FLAG | NETWORK_DOWN_FLAG)
+
+#define EVENT_TIMEOUT 5000
+
+static osEventFlagsId_t event_flags_id;
+
+/** Wait for specific event and check error */
+static int wait_for_event(uint32_t event)
+{
+    int res = EXIT_SUCCESS;
+    int ret = osEventFlagsWait(event_flags_id, ALL_EVENTS_FLAGS, osFlagsWaitAny, EVENT_TIMEOUT);
+    if (ret < 0)
+    {
+        ChipLogError(NotSpecified, "osEventFlagsWait failed %d", ret);
+        return EXIT_FAILURE;
+    }
+
+    if (!(ret & event))
+    {
+        res = EXIT_FAILURE;
+    }
+
+    ret = osEventFlagsClear(event_flags_id, ALL_EVENTS_FLAGS);
+    if (ret < 0)
+    {
+        ChipLogError(NotSpecified, "osEventFlagsClear failed %d", ret);
+        return EXIT_FAILURE;
+    }
+
+    return res;
+}
+
+/** This callback is called by the ip network task. It translates from a network event code
+ * to platform event and sends it.
+ *
+ * @param event network up or down event.
+ */
+static void network_state_callback(network_state_callback_event_t event)
+{
+    uint32_t event_flag = (event == NETWORK_UP) ? NETWORK_UP_FLAG : NETWORK_DOWN_FLAG;
+    ChipLogDetail(NotSpecified, "Network %s", (event == NETWORK_UP) ? "UP" : "DOWN");
+    int res = osEventFlagsSet(event_flags_id, event_flag);
+    if (res < 0)
+    {
+        ChipLogError(NotSpecified, "osEventFlagsSet failed %d", res);
+    }
+}
+
+int openiotsdk_platform_init(void)
+{
+    int ret;
+    osKernelState_t state;
+
+    ret = mbedtls_platform_setup(NULL);
+    if (ret)
+    {
+        ChipLogError(NotSpecified, "Mbed TLS platform initialization failed: %d", ret);
+        return EXIT_FAILURE;
+    }
+
+    ret = osKernelInitialize();
+    if (ret != osOK)
+    {
+        ChipLogError(NotSpecified, "osKernelInitialize failed: %d", ret);
+        return EXIT_FAILURE;
+    }
+
+    state = osKernelGetState();
+    if (state != osKernelReady)
+    {
+        ChipLogError(NotSpecified, "Kernel not ready: %d", state);
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}
+
+int openiotsdk_chip_init(void)
+{
+    CHIP_ERROR err;
+
+#if NDEBUG
+    chip::Logging::SetLogFilter(chip::Logging::LogCategory::kLogCategory_Progress);
+#endif
+
+    err = MemoryInit();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(NotSpecified, "Memory initialization failed: %s", err.AsString());
+        return EXIT_FAILURE;
+    }
+
+    err = PlatformMgr().InitChipStack();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(NotSpecified, "Chip stack initialization failed: %s", err.AsString());
+        return EXIT_FAILURE;
+    }
+
+    err = PlatformMgr().StartEventLoopTask();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(NotSpecified, "Chip stack start failed: %s", err.AsString());
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}
+
+int openiotsdk_platform_run(void)
+{
+    int ret = osKernelStart();
+    if (ret != osOK)
+    {
+        ChipLogError(NotSpecified, "Failed to start kernel: %d", ret);
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}
+
+int openiotsdk_network_init(bool wait)
+{
+    int ret;
+
+    event_flags_id = osEventFlagsNew(NULL);
+    if (event_flags_id == NULL)
+    {
+        ChipLogError(NotSpecified, "Create event flags failed");
+        return EXIT_FAILURE;
+    }
+
+    ret = start_network_task(network_state_callback, NETWORK_THREAD_STACK_SIZE_DEFAULT);
+    if (ret != osOK)
+    {
+        ChipLogError(NotSpecified, "start_network_task failed %d", ret);
+        return EXIT_FAILURE;
+    }
+
+    if (wait && wait_for_event(NETWORK_UP_FLAG) != EXIT_SUCCESS)
+    {
+        ChipLogError(NotSpecified, "Network initalization failed");
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/examples/platform/openiotsdk/app/openiotsdk_platform.h
+++ b/examples/platform/openiotsdk/app/openiotsdk_platform.h
@@ -1,0 +1,69 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file provides the common Open IoT SDK platform functions.
+ *      It can be used in Matter examples implementation.
+ */
+
+#ifndef OPENIOTSDK_PLATFORM_H
+#define OPENIOTSDK_PLATFORM_H
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+// Default stack size for network thread (8kB)
+#define NETWORK_THREAD_STACK_SIZE_DEFAULT (8 * 1024)
+
+/**
+ * @brief Initialise the Open IoT SDK platform
+ * Mbedtls platform setup
+ * OS kernel initialization and check
+ *
+ * @return EXIT_SUCCESS or EXIT_FAILURE
+ */
+int openiotsdk_platform_init(void);
+
+/**
+ * @brief Initialise the CHIP sources
+ * Platform memory and CHIP stack initialization
+ * Start CHIP event loop task
+ *
+ * @return EXIT_SUCCESS or EXIT_FAILURE
+ */
+int openiotsdk_chip_init(void);
+
+/**
+ * @brief Run the Open IoT SDK platform
+ * Start the OS kernel
+ *
+ * @return EXIT_SUCCESS or EXIT_FAILURE
+ */
+int openiotsdk_platform_run(void);
+
+/**
+ * @brief Initialise the Open IoT SDK network
+ * Run the network task and wait for newtork up
+ *
+ * @param wait Wait for network up
+ * @return EXIT_SUCCESS or EXIT_FAILURE
+ */
+int openiotsdk_network_init(bool wait);
+
+#endif /* ! OPENIOTSDK_PLATFORM_H */

--- a/examples/shell/openiotsdk/CMakeLists.txt
+++ b/examples/shell/openiotsdk/CMakeLists.txt
@@ -40,20 +40,23 @@ add_executable(${APP_TARGET})
 set(CONFIG_CHIP_LIB_SHELL YES)
 include(${OPENIOTSDK_COMMON}/cmake/chip.cmake)
 
-target_include_directories(${APP_TARGET} PRIVATE
-                           main/include
-                           ${SHELL_COMMON}/include
+add_subdirectory(${OPENIOTSDK_COMMON}/app ./app_build)
+
+target_include_directories(${APP_TARGET} 
+    PRIVATE
+        main/include
+        ${SHELL_COMMON}/include
 )
 
-target_sources(${APP_TARGET} PRIVATE
-                main/main.cpp
-                ${SHELL_COMMON}/cmd_misc.cpp
-                ${SHELL_COMMON}/globals.cpp
+target_sources(${APP_TARGET} 
+    PRIVATE
+        main/main.cpp
+        ${SHELL_COMMON}/cmd_misc.cpp
+        ${SHELL_COMMON}/globals.cpp
 )
 
-target_link_libraries(${APP_TARGET} 
-    cmsis-rtos-implementation
-    openiotsdk-chip
+target_link_libraries(${APP_TARGET}
+    openiotsdk-app
 )
 
 include(${OPENIOTSDK_COMMON}/cmake/linker.cmake)

--- a/examples/shell/openiotsdk/main/main.cpp
+++ b/examples/shell/openiotsdk/main/main.cpp
@@ -18,85 +18,58 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <lib/core/CHIPConfig.h>
 #include <lib/shell/Engine.h>
-#include <lib/support/CHIPMem.h>
 #include <lib/support/logging/CHIPLogging.h>
-#include <platform/CHIPDeviceLayer.h>
 
 #include <ChipShellCollection.h>
 
-#include "cmsis_os2.h"
-#include "mbedtls/platform.h"
+#include "openiotsdk_platform.h"
 
 using namespace ::chip;
 using namespace ::chip::Shell;
-using namespace ::chip::DeviceLayer;
 using namespace ::chip::Logging::Platform;
 
 static void app_thread(void * argument)
 {
+    int ret;
+
+    if (openiotsdk_network_init(true))
+    {
+        ChipLogError(Shell, "Network initialization failed");
+        goto exit;
+    }
+
     // Initialize the default streamer that was linked.
-    auto ret = Engine::Root().Init();
+    ret = Engine::Root().Init();
     if (ret)
     {
         ChipLogError(Shell, "Streamer initialization failed [%d]", ret);
-        return;
+        goto exit;
     }
 
     cmd_misc_init();
 
     ChipLogProgress(Shell, "Open IoT SDK shell example application run");
 
-#if NDEBUG
-    chip::Logging::SetLogFilter(chip::Logging::LogCategory::kLogCategory_None);
-#endif
-
     Engine::Root().RunMainLoop();
+
+exit:
+    osThreadTerminate(osThreadGetId());
 }
 
 int main()
 {
-    int ret        = 0;
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    osThreadId_t appThread;
-    osKernelState_t state;
-
     ChipLogProgress(Shell, "Open IoT SDK shell example application start");
 
-    ret = mbedtls_platform_setup(NULL);
-    if (ret)
+    if (openiotsdk_platform_init())
     {
-        ChipLogError(Shell, "Mbed TLS platform initialization failed: %d", ret);
+        ChipLogError(Shell, "Open IoT SDK platform initialization failed");
         return EXIT_FAILURE;
     }
 
-    ret = osKernelInitialize();
-    if (ret != osOK)
+    if (openiotsdk_chip_init())
     {
-        ChipLogError(Shell, "osKernelInitialize failed: %d", ret);
-        return EXIT_FAILURE;
-    }
-
-    err = chip::Platform::MemoryInit();
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(Shell, "Memory initialization failed: %s", err.AsString());
-        return EXIT_FAILURE;
-    }
-
-    err = PlatformMgr().InitChipStack();
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(Shell, "Chip stack initialization failed: %s", err.AsString());
-        return EXIT_FAILURE;
-    }
-
-    err = PlatformMgr().StartEventLoopTask();
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(Shell, "Chip stack start failed: %s", err.AsString());
+        ChipLogError(Shell, "Open IoT SDK CHIP stack initialization failed");
         return EXIT_FAILURE;
     }
 
@@ -104,26 +77,16 @@ int main()
         .stack_size = 8 * 1024 // Allocate enough stack for app thread
     };
 
-    appThread = osThreadNew(app_thread, NULL, &thread_attr);
+    osThreadId_t appThread = osThreadNew(app_thread, NULL, &thread_attr);
     if (appThread == NULL)
     {
         ChipLogError(Shell, "Failed to create app thread");
         return EXIT_FAILURE;
     }
 
-    state = osKernelGetState();
-    if (state == osKernelReady)
+    if (openiotsdk_platform_run())
     {
-        ret = osKernelStart();
-        if (ret != osOK)
-        {
-            ChipLogError(Shell, "Failed to start kernel: %d", ret);
-            return EXIT_FAILURE;
-        }
-    }
-    else
-    {
-        ChipLogError(Shell, "Kernel not ready: %d", state);
+        ChipLogError(Shell, "Open IoT SDK platform run failed");
         return EXIT_FAILURE;
     }
 


### PR DESCRIPTION
#### Problem
Add Open IoT SDK example platform target that contains source code shared between examples. 

#### Change overview
- Open IoT SDK app target
   - Add new target that contains common platform sources
   - Implement Open IoT SDK platform initialization file

- Shell example improvements
  - Add openiotsdk-app target to shell example
  - Terminate the application thread
 
- Move additional CHIP configuration to openiotsdk-chip target

#### Testing
Build and run shell example
