### PR TITLE
LwIP debug logging

### DIFF
--- a/config/openiotsdk/lwip/user_lwipopts.h
+++ b/config/openiotsdk/lwip/user_lwipopts.h
@@ -21,4 +21,26 @@
 
 #define LWIP_STATS (0)
 
+#ifdef LWIP_DEBUG
+
+// Debug Options
+#define NETIF_DEBUG LWIP_DBG_ON
+#define IP_DEBUG LWIP_DBG_ON
+#define TCP_DEBUG LWIP_DBG_ON
+#define UDP_DEBUG LWIP_DBG_ON
+#define IP6_DEBUG LWIP_DBG_ON
+
+#define LWIP_DBG_TYPES_ON LWIP_DBG_ON
+#define LWIP_DBG_MIN_LEVEL LWIP_DBG_LEVEL_ALL
+#endif
+
+#ifndef LWIP_PLATFORM_DIAG
+#define LWIP_PLATFORM_DIAG(x)                                                                                                      \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        DEBUG_PRINT x;                                                                                                             \
+        DEBUG_PRINT("\r");                                                                                                         \
+    } while (0)
+#endif
+
 #endif /* USER_LWIPOPTS_H */

--- a/examples/shell/openiotsdk/CMakeLists.txt
+++ b/examples/shell/openiotsdk/CMakeLists.txt
@@ -31,6 +31,13 @@ if(TARGET lwip-cmsis-port)
         INTERFACE
             ${OPEN_IOT_SDK_CONFIG}/lwip
     )
+
+    if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+        target_compile_definitions(lwipopts
+            INTERFACE
+                LWIP_DEBUG
+        )
+    endif()
 endif()
 
 project(${APP_TARGET} LANGUAGES C CXX ASM)


### PR DESCRIPTION
#### Problem
Add debug logging from LwIP to Open IoT SDK applications

#### Change overview
- Enable LwIP debug logs
   - Add debug log options to user_lwipopts
   - Set LWIP_DEBUG define for debug build
- Update Open IoT SDK version - contained LwIP fixes

#### Testing
Build and run applications in debug mode
