### PR TITLE
Platform : Make Event loop reentrant

### DIFF
--- a/src/platform/openiotsdk/BUILD.gn
+++ b/src/platform/openiotsdk/BUILD.gn
@@ -21,7 +21,6 @@ assert(chip_device_platform == "openiotsdk")
 static_library("openiotsdk") {
   sources = [
     "../SingletonConfigurationManager.cpp",
-    "arch.c",
     "BlePlatformConfig.h",
     "CHIPDevicePlatformConfig.h",
     "CHIPDevicePlatformEvent.h",
@@ -40,13 +39,15 @@ static_library("openiotsdk") {
     "Logging.cpp",
     "NetworkCommissioningDriver.h",
     "NetworkCommissioningEthernetDriver.cpp",
+    "OpenIoTSDKArchUtils.c",
+    "OpenIoTSDKArchUtils.h",
     "OpenIoTSDKConfig.cpp",
     "OpenIoTSDKConfig.h",
     "PlatformManagerImpl.cpp",
     "PlatformManagerImpl.h",
     "SystemPlatformConfig.h",
     "SystemTimeSupport.cpp",
-    "SystemTimeSupport.h"
+    "SystemTimeSupport.h",
   ]
 
   public_deps = [ "${chip_root}/src/platform:platform_base" ]

--- a/src/platform/openiotsdk/OpenIoTSDKArchUtils.c
+++ b/src/platform/openiotsdk/OpenIoTSDKArchUtils.c
@@ -20,8 +20,8 @@
  *          Open IOT SDK platform adaptation file
  */
 
-#include "cmsis_os2.h"
 #include <time.h>
+#include "OpenIoTSDKArchUtils.h"
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -50,7 +50,7 @@ void SetTick(uint64_t newTick)
 }
 
 /* Time to kernel ticks */
-static uint32_t ms2tick(uint32_t ms)
+uint32_t ms2tick(uint32_t ms)
 {
     if (ms == 0U) {
         return (osWaitForever);
@@ -67,7 +67,7 @@ static uint32_t ms2tick(uint32_t ms)
     return (ms);
 }
 
-static uint32_t us2tick(uint32_t usec)
+uint32_t us2tick(uint32_t usec)
 {
     if (usec == 0U) {
         return osWaitForever;

--- a/src/platform/openiotsdk/OpenIoTSDKArchUtils.h
+++ b/src/platform/openiotsdk/OpenIoTSDKArchUtils.h
@@ -1,0 +1,43 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Defines timing helper functions.
+ */
+
+#pragma once
+
+#include "cmsis_os2.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+uint64_t GetTick(void);
+
+void SetTick(uint64_t newTick);
+
+/* Time to kernel ticks */
+uint32_t ms2tick(uint32_t ms);
+
+uint32_t us2tick(uint32_t usec);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/platform/openiotsdk/SystemTimeSupport.cpp
+++ b/src/platform/openiotsdk/SystemTimeSupport.cpp
@@ -28,6 +28,7 @@
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
+#include "OpenIoTSDKArchUtils.h"
 #include "cmsis_os2.h"
 
 namespace chip {
@@ -43,9 +44,6 @@ ClockImpl gClockImpl;
 const uint32_t TICKS_PER_SECOND = osKernelGetTickFreq();
 const uint32_t US_PER_TICK      = 1000000 / TICKS_PER_SECOND;
 const uint32_t MS_PER_TICK      = US_PER_TICK / 1000;
-
-extern "C" uint64_t GetTick(void);
-extern "C" void SetTick(uint64_t newTick);
 
 Clock::Microseconds64 ClockImpl::GetMonotonicMicroseconds64(void)
 {


### PR DESCRIPTION
#### Problem
Some tests launch an event loop within an event loop. the CHIP documentation doesn't specify that this behavior is forbidden so our implementation should allow it, this PR makes it reentrant.

For more details on the test : check src/controller/tests/data_model : TestReadHandler_OneSubscribeMultipleReads

#### Change overview
* Make helpful timing functions available for platform files
* Make event loop reentrant.
